### PR TITLE
Fix native packaging and cross-platform JAR builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,14 @@ jobs:
   build-macos:
     needs: check-version
     if: needs.check-version.outputs.should_release == 'true'
-    runs-on: macos-latest
+    strategy:
+      matrix:
+        include:
+          - runner: macos-latest
+            arch: aarch64
+          - runner: macos-13
+            arch: x64
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
 
@@ -53,13 +60,20 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v4
 
-      - name: Package DMG
-        run: ./gradlew packageDmg
+      - name: Package DMG and uber JAR
+        run: ./gradlew packageDmg packageUberJarForCurrentOS
+
+      - name: Rename uber JAR
+        run: |
+          VERSION=${{ needs.check-version.outputs.version }}
+          mv build/compose/jars/*.jar "build/compose/jars/ME7Tuner-${VERSION}-macos-${{ matrix.arch }}.jar"
 
       - uses: actions/upload-artifact@v4
         with:
-          name: macos-dmg
-          path: build/compose/binaries/main/dmg/*.dmg
+          name: macos-${{ matrix.arch }}
+          path: |
+            build/compose/binaries/main/dmg/*.dmg
+            build/compose/jars/*.jar
 
   build-windows:
     needs: check-version
@@ -75,13 +89,21 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v4
 
-      - name: Package MSI
-        run: ./gradlew packageMsi
+      - name: Package MSI and uber JAR
+        run: ./gradlew packageMsi packageUberJarForCurrentOS
+
+      - name: Rename uber JAR
+        shell: bash
+        run: |
+          VERSION=${{ needs.check-version.outputs.version }}
+          mv build/compose/jars/*.jar "build/compose/jars/ME7Tuner-${VERSION}-windows-x64.jar"
 
       - uses: actions/upload-artifact@v4
         with:
-          name: windows-msi
-          path: build/compose/binaries/main/msi/*.msi
+          name: windows-packages
+          path: |
+            build/compose/binaries/main/msi/*.msi
+            build/compose/jars/*.jar
 
   build-linux:
     needs: check-version
@@ -97,47 +119,27 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v4
 
-      - name: Package DEB
-        run: ./gradlew packageDeb
+      - name: Package DEB and uber JAR
+        run: ./gradlew packageDeb packageUberJarForCurrentOS
 
-      - name: Create portable tar.gz
+      - name: Create portable tar.gz and rename uber JAR
         run: |
           ./gradlew createDistributable
           VERSION=${{ needs.check-version.outputs.version }}
           tar -czf "ME7Tuner-${VERSION}-linux-x64.tar.gz" \
             -C build/compose/binaries/main/app .
+          mv build/compose/jars/*.jar "build/compose/jars/ME7Tuner-${VERSION}-linux-x64.jar"
 
       - uses: actions/upload-artifact@v4
         with:
           name: linux-packages
           path: |
             build/compose/binaries/main/deb/*.deb
+            build/compose/jars/*.jar
             ME7Tuner-*-linux-x64.tar.gz
 
-  build-jar:
-    needs: check-version
-    if: needs.check-version.outputs.should_release == 'true'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 17
-
-      - uses: gradle/actions/setup-gradle@v4
-
-      - name: Package uber JAR
-        run: ./gradlew packageUberJarForCurrentOS
-
-      - uses: actions/upload-artifact@v4
-        with:
-          name: uber-jar
-          path: build/compose/jars/*.jar
-
   release:
-    needs: [check-version, build-macos, build-windows, build-linux, build-jar]
+    needs: [check-version, build-macos, build-windows, build-linux]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/download-artifact@v4

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -63,6 +63,8 @@ compose.desktop {
             packageVersion = appVersion
             description = "ME7 M-box ECU Calibration Tool"
 
+            includeAllModules = true
+
             macOS {
                 bundleID = "com.tracqi.me7tuner"
             }

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,4 +2,4 @@ org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
 kotlin.code.style=official
 kotlin.version=2.2.20
 compose.version=1.10.1
-app.version=2.0.0
+app.version=2.0.1


### PR DESCRIPTION
## Summary
- Fix "Failed to launch JVM" on Windows MSI and broken macOS DMG by adding `includeAllModules = true` to jlink configuration — ensures all required JVM modules (java.scripting, java.prefs, etc.) are bundled
- Fix missing `skiko-windows-x64.dll.sha256` in uber JAR by building per-platform JARs on each OS runner instead of Linux-only
- Add macOS x64 (Intel) build alongside aarch64 (Apple Silicon) — `macos-latest` is now ARM-only, so Intel Mac users were getting an incompatible DMG
- Bump to v2.0.1

## Changes
- `build.gradle.kts`: add `includeAllModules = true` to `nativeDistributions`
- `.github/workflows/release.yml`: per-platform uber JARs, dual-arch macOS matrix, remove standalone `build-jar` job
- `gradle.properties`: version bump 2.0.0 → 2.0.1

## Test plan
- [ ] Release workflow triggers on merge and all 4 platform jobs succeed
- [ ] Windows MSI installs and launches without "Failed to launch JVM"
- [ ] macOS DMGs work on both Intel and Apple Silicon
- [ ] Per-platform uber JARs launch correctly on their target OS

🤖 Generated with [Claude Code](https://claude.com/claude-code)