### PR TITLE
Fix Windows build: quote Gradle property for PowerShell

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,7 +87,8 @@ jobs:
       - uses: gradle/actions/setup-gradle@v4
 
       - name: Package MSI and uber JAR
-        run: ./gradlew packageMsi packageUberJarForCurrentOS -Papp.version=${{ needs.check-version.outputs.version }}
+        shell: bash
+        run: ./gradlew packageMsi packageUberJarForCurrentOS "-Papp.version=${{ needs.check-version.outputs.version }}"
 
       - name: Rename uber JAR
         shell: bash


### PR DESCRIPTION
## Summary
- PowerShell splits `-Papp.version=2.0.1` into `-P` + `app` (task not found error)
- Fix: use `shell: bash` and quote the property arg on the Windows build step

## Test plan
- [ ] Windows build-windows job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)