### PR TITLE
Fix missing macOS/Windows artifacts in releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,10 +137,15 @@ jobs:
           merge-multiple: true
           path: artifacts
 
+      - name: Flatten artifacts
+        run: |
+          mkdir -p flat
+          find artifacts -type f \( -name '*.dmg' -o -name '*.msi' -o -name '*.deb' -o -name '*.jar' -o -name '*.tar.gz' \) -exec cp {} flat/ \;
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: v${{ needs.check-version.outputs.version }}
           name: ME7Tuner ${{ needs.check-version.outputs.version }}
           generate_release_notes: true
-          files: artifacts/*
+          files: flat/*


### PR DESCRIPTION
## Summary
- `download-artifact@v4` with `merge-multiple` preserves nested directory structure (`build/compose/binaries/main/dmg/`, etc.)
- `softprops/action-gh-release`'s `files: artifacts/*` only matches top-level files, so only the Linux tar.gz (which was at the root) made it into v2.0.1
- Adds a flatten step that copies all `.dmg`, `.msi`, `.deb`, `.jar`, and `.tar.gz` files into a single `flat/` directory before the release upload

## Test plan
- [ ] Merge to master and verify the next release contains all expected artifacts: DMG, MSI, DEB, tar.gz, and 3 uber JARs
- [ ] Optionally re-release v2.0.1 by deleting the tag/release and re-triggering

🤖 Generated with [Claude Code](https://claude.com/claude-code)