### PR TITLE
fix: set XdfFilePreferences in Med17 test base to fix CI failures

### DIFF
--- a/src/test/kotlin/ui/screens/med17/Med17ScreenTestBase.kt
+++ b/src/test/kotlin/ui/screens/med17/Med17ScreenTestBase.kt
@@ -6,6 +6,7 @@ import data.parser.xdf.TableDefinition
 import data.parser.xdf.XdfParser
 import data.preferences.bin.BinFilePreferences
 import data.preferences.platform.EcuPlatformPreference
+import data.preferences.xdf.XdfFilePreferences
 import data.profile.ConfigurationProfile
 import data.profile.ProfileManager
 import domain.math.map.Map3d
@@ -45,6 +46,7 @@ abstract class Med17ScreenTestBase {
     }
 
     protected lateinit var savedPlatform: EcuPlatform
+    protected lateinit var savedXdfFile: File
     protected lateinit var tableDefs: List<TableDefinition>
     protected lateinit var allMaps: List<Pair<TableDefinition, Map3d>>
     protected lateinit var tempBinFile: File
@@ -54,6 +56,7 @@ abstract class Med17ScreenTestBase {
     @BeforeTest
     open fun setUp() {
         savedPlatform = EcuPlatformPreference.platform
+        savedXdfFile = XdfFilePreferences.getStoredFile()
         EcuPlatformPreference.platform = EcuPlatform.MED17
 
         assertTrue(XDF_FILE.exists(), "XDF not found: ${XDF_FILE.absolutePath}")
@@ -73,6 +76,7 @@ abstract class Med17ScreenTestBase {
         tempBinFile = File.createTempFile("med17_test_", ".bin")
         BIN_FILE.copyTo(tempBinFile, overwrite = true)
         BinFilePreferences.setFile(tempBinFile)
+        XdfFilePreferences.setFile(XDF_FILE)
 
         stockBinCopy = File.createTempFile("med17_stock_", ".bin")
         BIN_FILE.copyTo(stockBinCopy, overwrite = true)
@@ -90,6 +94,7 @@ abstract class Med17ScreenTestBase {
     @AfterTest
     open fun tearDown() {
         EcuPlatformPreference.platform = savedPlatform
+        XdfFilePreferences.setFile(savedXdfFile)
         if (::tempBinFile.isInitialized && tempBinFile.exists()) {
             tempBinFile.delete()
         }


### PR DESCRIPTION
## Summary
- Fix 3 failing `Med17ConfigurationScreenTest` tests by setting `XdfFilePreferences.setFile(XDF_FILE)` in `Med17ScreenTestBase.setUp()`
- `ConfigurationScreen` guards map definitions behind `filesLoaded` (requires both XDF + BIN preferences set); the test base only set `BinFilePreferences`, causing `FilesNotLoadedPlaceholder` to render instead of map definitions
- Save/restore `XdfFilePreferences` in tearDown following the existing pattern for `savedPlatform`

## Test plan
- [x] `./gradlew test --tests "ui.screens.med17.Med17ConfigurationScreenTest"` — all 4 tests pass
- [ ] Full test suite passes on CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)