### PR TITLE
Fix KFLF documentation: injection correction factor, not lambda target

### DIFF
--- a/documentation/me7-calibration-guide.md
+++ b/documentation/me7-calibration-guide.md
@@ -137,7 +137,7 @@ TVUB is a 1D Kennlinie: battery voltage (V) → dead time (ms). Dead time (Venti
 
 #### KFLF Clarification
 
-KFLF exists in ME7 but is "Lambda map at partial load" — a partial-load AFR target map (RPM × load → lambda). It is **NOT** an injector linearization table. There is no "KFLFW" injector linearization in ME7. ME7 handles minimum pulse width via the TEMIN constant.
+KFLF (Lambdakennfeld bei Teillast — "Lambda map at partial load") is **misnamed**. Despite the name, it is NOT a lambda target map. It is a multiplicative injection correction factor (1.0 = no correction, >1.0 = richer, <1.0 = leaner). The FR explicitly states: "Das Kennfeld KFLF sollte nicht zu Gemischeingriffen verwendet werden" — KFLF should not be used for mixture intervention. Use KFPU for relative charge alignment instead. There is no "KFLFW" injector linearization in ME7. ME7 handles minimum pulse width via the TEMIN constant.
 
 #### Usage
 

--- a/src/main/kotlin/domain/model/injector/InjectorScalingSolver.kt
+++ b/src/main/kotlin/domain/model/injector/InjectorScalingSolver.kt
@@ -20,8 +20,8 @@ import kotlin.math.sqrt
  * There is no "KFLFW" injector linearization curve either — ME7 handles
  * minimum pulse width via the TEMIN constant.
  *
- * Note: KFLF exists but is "Lambda map at partial load" (Kennfeld Lambda
- * Teillast) — a partial-load AFR target map, NOT injector linearization.
+ * Note: KFLF ("Lambdakennfeld bei Teillast") is misnamed — it is actually
+ * a multiplicative injection correction factor (1.0 = neutral), NOT a lambda target.
  *
  * ## Scaling When Changing Injectors
  *

--- a/src/main/kotlin/ui/screens/fueling/FuelingScreen.kt
+++ b/src/main/kotlin/ui/screens/fueling/FuelingScreen.kt
@@ -450,7 +450,7 @@ private fun InjectorScalingTab() {
                             "ME7 computes injection time as: te = rk_w × KRKTE + TVUB(ubat)\n" +
                                 "• KRKTE — scalar injector constant [ms/%] (me7-raw.txt line 222175)\n" +
                                 "• TVUB — dead time vs battery voltage (me7-raw.txt line 183466)\n" +
-                                "• KFLF — NOT injector-related; it is 'Lambda map at partial load' (AFR target)\n" +
+                                "• KFLF — misnamed 'Lambda map at partial load'; actually an injection correction factor (1.0=neutral)\n" +
                                 "• There is no KFTI (2D injection time map) or KFLFW (linearization) in ME7"
                     },
                     style = MaterialTheme.typography.bodySmall,


### PR DESCRIPTION
## Summary

KFLF (`Lambdakennfeld bei Teillast`) is misnamed in ME7. Despite the name "Lambda map at partial load," it is a **multiplicative injection correction factor** (1.0 = neutral, >1.0 = richer, <1.0 = leaner), not an AFR target map.

## Evidence

- **Funktionsrahmen** (me7-raw.txt line 158470): *"Das Kennfeld KFLF sollte nicht zu Gemischeingriffen verwendet werden"* — KFLF should not be used for mixture intervention
- **XDF data** (8D0907551M): Values are 0.85–1.02, centered at 1.0 — consistent with correction factors, not lambda targets
- **s4wiki.com/wiki/Tuning**: Correctly describes KFLF as "not lambda at all" and "an injector on time scaling table"
- **Motronic 3.8x–5.9x doc** (in this repo): Also correctly identifies KFLF as injection correction factors

The ME7 calibration guide, UI tooltip, and InjectorScalingSolver KDoc all previously described KFLF as a lambda/AFR target map, which was incorrect.

## Changes

- `documentation/me7-calibration-guide.md` — Corrected KFLF Clarification section
- `FuelingScreen.kt` — Updated UI tooltip text
- `InjectorScalingSolver.kt` — Updated KDoc comment